### PR TITLE
Run as Network Service and service definition cleanup

### DIFF
--- a/src/Lighthouse/LighthouseService.cs
+++ b/src/Lighthouse/LighthouseService.cs
@@ -10,12 +10,12 @@
 // under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the 
 // specific language governing permissions and limitations under the License.
+using System.Threading.Tasks;
 using Akka.Actor;
-using Topshelf;
 
 namespace Lighthouse
 {
-    public class LighthouseService : ServiceControl
+    public class LighthouseService
     {
         private readonly string _ipAddress;
         private readonly int? _port;
@@ -30,16 +30,14 @@ namespace Lighthouse
             _port = port;
         }
 
-        public bool Start(HostControl hostControl)
+        public void Start()
         {
             _lighthouseSystem = LighthouseHostFactory.LaunchLighthouse(_ipAddress, _port);
-            return true;
         }
 
-        public bool Stop(HostControl hostControl)
+        public async Task StopAsync()
         {
-            _lighthouseSystem.Shutdown();
-            return true;
+            await _lighthouseSystem.Terminate();
         }
     }
 }

--- a/src/Lighthouse/Program.cs
+++ b/src/Lighthouse/Program.cs
@@ -20,15 +20,20 @@ namespace Lighthouse
         {
             return (int) HostFactory.Run(x =>
             {
+                x.Service<LighthouseService>(s =>
+                {
+                    s.ConstructUsing(ss => new LighthouseService());
+                    s.WhenStarted(ss => ss.Start());
+                    s.WhenStopped(ss => ss.StopAsync().Wait());
+                });
+
                 x.SetServiceName("Lighthouse");
                 x.SetDisplayName("Lighthouse Service Discovery");
                 x.SetDescription("Lighthouse Service Discovery for Akka.NET Clusters");
                 
-                x.UseAssemblyInfoForServiceInfo();
                 x.RunAsLocalSystem();
                 x.StartAutomatically();
                 x.UseNLog();
-                x.Service<LighthouseService>();
                 x.EnableServiceRecovery(r => r.RestartService(1));
             });
         }

--- a/src/Lighthouse/Program.cs
+++ b/src/Lighthouse/Program.cs
@@ -30,8 +30,8 @@ namespace Lighthouse
                 x.SetServiceName("Lighthouse");
                 x.SetDisplayName("Lighthouse Service Discovery");
                 x.SetDescription("Lighthouse Service Discovery for Akka.NET Clusters");
-                
-                x.RunAsLocalSystem();
+
+                x.RunAsNetworkService();
                 x.StartAutomatically();
                 x.UseNLog();
                 x.EnableServiceRecovery(r => r.RestartService(1));


### PR DESCRIPTION
* **Service metadata fix** (service name, display name etc.), removed `UseAssemblyInfoForServiceInfo()`
*  **Async stop method** with `_lighthouseSystem.Terminate()` instead of deprecated Shutdown. Looks cleaner :)
* **Run as NETWORK SERVICE**. Lighthouse doesn't need LOCAL SYSTEM account.

Plus potential ability to pass IP and port from command line arguments as `LighthouseService` constructor was opened.