### PR TITLE
V1.3.5 upgrade and Petabridge.Cmd Installation

### DIFF
--- a/src/Lighthouse/Lighthouse.csproj
+++ b/src/Lighthouse/Lighthouse.csproj
@@ -4,11 +4,10 @@
     <TargetFrameworks>netcoreapp1.1;net452</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Akka" Version="1.3.2" />
-    <PackageReference Include="Akka.Cluster" Version="1.3.2" />
-    <PackageReference Include="Akka.Remote" Version="1.3.2" />
+    <PackageReference Include="Akka.Cluster" Version="1.3.5" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="1.1.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="1.1.2" />
+    <PackageReference Include="Petabridge.Cmd.Cluster" Version="0.3.3" />
   </ItemGroup>
   <!-- Conditionally obtain references for .NET Framework 4.5.2 -->
   <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">

--- a/src/Lighthouse/LighthouseService.cs
+++ b/src/Lighthouse/LighthouseService.cs
@@ -13,6 +13,8 @@
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Cluster;
+using Petabridge.Cmd.Cluster;
+using Petabridge.Cmd.Host;
 
 namespace Lighthouse
 {
@@ -34,6 +36,9 @@ namespace Lighthouse
         public void Start()
         {
             _lighthouseSystem = LighthouseHostFactory.LaunchLighthouse(_ipAddress, _port);
+            var pbm = PetabridgeCmd.Get(_lighthouseSystem);
+            pbm.RegisterCommandPalette(ClusterCommands.Instance); // enable cluster management commands
+            pbm.Start();
         }
 
         public async Task StopAsync()

--- a/src/Lighthouse/LighthouseService.cs
+++ b/src/Lighthouse/LighthouseService.cs
@@ -1,4 +1,16 @@
-﻿using System.Threading.Tasks;
+﻿// Copyright 2014-2015 Aaron Stannard, Petabridge LLC
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use 
+// this file except in compliance with the License. You may obtain a copy of the 
+// License at 
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0 
+// 
+// Unless required by applicable law or agreed to in writing, software distributed 
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// specific language governing permissions and limitations under the License.
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Cluster;
 

--- a/src/Lighthouse/akka.hocon
+++ b/src/Lighthouse/akka.hocon
@@ -2,6 +2,16 @@ lighthouse{
   actorsystem: "actor-system" #POPULATE NAME OF YOUR ACTOR SYSTEM HERE
 }
 
+# See petabridge.cmd configuration options here: https://cmd.petabridge.com/articles/install/host-configuration.html
+petabridge.cmd{
+	# default IP address used to listen for incoming petabridge.cmd client connections
+	# should be a safe default as it listens on "all network interfaces".
+	host = "0.0.0.0"
+
+	# default port number used to listen for incoming petabridge.cmd client connections
+	port = 9110
+}
+
 akka {
   actor {
     provider = cluster


### PR DESCRIPTION
Lighthouse now ships with [Petabridge.Cmd](https://cmd.petabridge.com/) enabled with cluster management commands by default. We'll want to update the README to that effect. 