### PR TITLE
[WIP] Docker integration

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+src\*\bin\
+src\*\obj\
+src\Ligthouse.Tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,14 @@
-FROM microsoft/aspnetcore-build:1.1 AS build-env
+FROM microsoft/dotnet:1.1-sdk AS build-env
 WORKDIR /app
 
-COPY *.sln .
-COPY src/Lighthouse/*.csproj ./src/Lighthouse
+COPY src/Lighthouse/*.csproj ./
 RUN dotnet restore
 
-COPY . ./
-WORKDIR /app/src/Lighthouse
+COPY src/Lighthouse ./
 RUN dotnet publish -c Release --framework netcoreapp1.1 -o out
 
-FROM microsoft/aspnetcore:1.1
-WORKDIR /app/src/Lighthouse
-COPY --from=build-env /app/src/Lighthouse/out .
-ENTRYPOINT ["dotnet", "lighthouse.dll"]
+FROM microsoft/dotnet:1.1-runtime AS runtime
+WORKDIR /app
+COPY --from=build-env /app/out ./
+RUN ls
+ENTRYPOINT ["dotnet", "Lighthouse.dll"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM microsoft/aspnetcore-build:1.1 AS build-env
+WORKDIR /app
+
+COPY *.sln .
+COPY src/Lighthouse/*.csproj ./src/Lighthouse
+RUN dotnet restore
+
+COPY . ./
+WORKDIR /app/src/Lighthouse
+RUN dotnet publish -c Release --framework netcoreapp1.1 -o out
+
+FROM microsoft/aspnetcore:1.1
+WORKDIR /app/src/Lighthouse
+COPY --from=build-env /app/src/Lighthouse/out .
+ENTRYPOINT ["dotnet", "lighthouse.dll"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,26 @@
 FROM microsoft/dotnet:1.1-sdk AS build-env
 WORKDIR /app
 
+ENV ACTORSYSTEM "lighthouse"
+
+# should be a comma-delimited list
+ENV SEEDS "[]"
+
 COPY src/Lighthouse/*.csproj ./
 RUN dotnet restore
 
+RUN ls
 COPY src/Lighthouse ./
 RUN dotnet publish -c Release --framework netcoreapp1.1 -o out
 
 FROM microsoft/dotnet:1.1-runtime AS runtime
 WORKDIR /app
 COPY --from=build-env /app/out ./
-RUN ls
-ENTRYPOINT ["dotnet", "Lighthouse.dll"]
+COPY --from=build-env /app/get-dockerip.sh ./get-dockerip.sh
+ENTRYPOINT ["/bin/bash","get-dockerip.sh"]
+
+# 9110 - Petabridge.Cmd
+# 4053 - Akka.Cluster
+EXPOSE 9110 4053
+
+CMD ["dotnet", "Lighthouse.dll"]

--- a/src/Lighthouse/LighthouseService.cs
+++ b/src/Lighthouse/LighthouseService.cs
@@ -10,6 +10,8 @@
 // under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the 
 // specific language governing permissions and limitations under the License.
+
+using System;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Cluster;
@@ -22,20 +24,27 @@ namespace Lighthouse
     {
         private readonly string _ipAddress;
         private readonly int? _port;
+        private readonly string _actorSystemName;
 
         private ActorSystem _lighthouseSystem;
 
-        public LighthouseService() : this(null, null) { }
+        /*
+        * var ipAddress = ;
+            var actorSystemName = Environment.GetEnvironmentVariable("actorSystemName"); 
+        */
 
-        public LighthouseService(string ipAddress, int? port)
+        public LighthouseService() : this(Environment.GetEnvironmentVariable("CONTAINER_IP"), null, Environment.GetEnvironmentVariable("ACTORSYSTEM")) { }
+
+        public LighthouseService(string ipAddress, int? port, string actorSystemName)
         {
             _ipAddress = ipAddress;
             _port = port;
+            _actorSystemName = actorSystemName;
         }
 
         public void Start()
         {
-            _lighthouseSystem = LighthouseHostFactory.LaunchLighthouse(_ipAddress, _port);
+            _lighthouseSystem = LighthouseHostFactory.LaunchLighthouse(_ipAddress, _port, _actorSystemName);
             var pbm = PetabridgeCmd.Get(_lighthouseSystem);
             pbm.RegisterCommandPalette(ClusterCommands.Instance); // enable cluster management commands
             pbm.Start();

--- a/src/Lighthouse/get-dockerip.sh
+++ b/src/Lighthouse/get-dockerip.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+host=$(hostname -i)
+echo "Docker container bound on $host"
+export CONTAINER_IP="$host"
+
+exec "$@"


### PR DESCRIPTION
So far it works! But I need to add some documentation and some CI around the Docker images. 

You can play around with the real thing here: https://hub.docker.com/r/petabridge/lighthouse/

For best results, you'd want to run something along the lines of:

```
PS> docker pull petabridge/lighthouse:latest
PS>docker run -d -p 7000:9110 -p 5000:4053 --name lighthouse1 petabridge/lighthouse:latest
```

The image uses 9110 for Petabridge.Cmd and 4053 for Lighthouse's Akka.Cluster connection. The Akka.Cluster bits of this container aren't designed to be networked using the host bridge; meaning, you can't connect to this container's Akka.Cluster endpoint using another node that's running on the host machine. Instead, this is designed for building an elastic network on top of the Docker vnet. Before I put the finishing touches on this and document how it all works, I'll have all of WebCrawler Dockerized with a `docker-compose` sample to show how everything fits together.

So that's why this is in a "work in progress" state for the time being - might need to smooth some stuff out once I do the integration with WebCrawler. But otherwise, the `Dockerfile` included in this PR can reliably be used as a future reference.