### PR TITLE
Casting list to string[] causing an exception during start up.

### DIFF
--- a/src/Lighthouse/LighthouseHostFactory.cs
+++ b/src/Lighthouse/LighthouseHostFactory.cs
@@ -60,7 +60,7 @@ namespace Lighthouse
             var seeds = clusterConfig.GetStringList("akka.cluster.seed-nodes");
             if (!string.IsNullOrEmpty(clusterSeeds))
             {
-                var tempSeeds = clusterSeeds.Trim('[', ']').Split(',');
+                var tempSeeds = clusterSeeds.Trim('[', ']').Split(',').ToList();
                 if (tempSeeds.Any())
                 {
                     seeds = tempSeeds;


### PR DESCRIPTION
In the scenario where you dynamically add additional lighthouse workers to a known set of seed nodes then following error is thrown.

```
Unhandled Exception: System.NotSupportedException: Collection was of a fixed size.
   at System.ThrowHelper.ThrowNotSupportedException(ExceptionResource resource)
   at Lighthouse.LighthouseHostFactory.LaunchLighthouse(String ipAddress, Nullable`1 specifiedPort, String systemName) in /app/LighthouseHostFactory.cs:line 76
   at Lighthouse.LighthouseService.Start() in /app/LighthouseService.cs:line 42
   at Lighthouse.Program.Main(String[] args) in /app/Program.NetCore.cs:line 12
```

The error only occurs when both conditions on line 61 and line 71 are true.

Sample `docker-compose` highlighting the issue.

```
  lighthouse-0:
    image: petabridge/lighthouse:v0.9.2
    ports:
      - '127.0.0.1:9110:9110'
      - '127.0.0.1:4053:4053'
    environment:
      ACTORSYSTEM: "testsystem"
      CLUSTER_IP: 127.0.0.1
      CLUSTER_PORT: 4053
      CLUSTER_SEEDS: "akka.tcp://testsystem@127.0.0.1:4053"

  lighthouse-1:
    image: petabridge/lighthouse:v0.9.2
    ports:
      - '127.0.0.1:4054:4054'
    environment:
      ACTORSYSTEM: "testsystem"
      CLUSTER_IP: 127.0.0.1
      CLUSTER_PORT: 4054
      CLUSTER_SEEDS: "akka.tcp://testsystem@127.0.0.1:4053"
```