### PR TITLE
Shell script format fix

### DIFF
--- a/src/Lighthouse/get-dockerip.sh
+++ b/src/Lighthouse/get-dockerip.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-if [ -z "$CLUSTER_IP"]; then
+if [ -z "$CLUSTER_IP" ]; then
 	host=$(hostname -i)
 	echo "Docker container bound on $host"
 	export CLUSTER_IP="$host"


### PR DESCRIPTION
An error occurs if you tail the log files during startup.

```
get-dockerip.sh: line 3: [: missing `]'
```

Simple formatting fix.