### PR TITLE
v1.1 Release

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,3 @@
-#### 1.0.0 May 13 2019 ####
-* Upgraded to Akka.NET v1.3.13
-* Installed [Akka.Bootstrap.Docker](https://github.com/petabridge/akkadotnet-bootstrap)
-* Added separately tagged [Windows and Linux Lighthouse Docker images to `petabridge/lighthouse` on DockerHub](https://hub.docker.com/r/petabridge/lighthouse).
-* Upgraded to .NET 4.6.1 and .NET Core 2.1, respectively. 
+#### 1.1.0 June 26 2019 ####
+* Reduced [Docker image size by a factor of 10](https://github.com/petabridge/lighthouse/pull/84).
+* Upgraded to [Petabridge.Cmd v0.6.2](https://cmd.petabridge.com/articles/RELEASE_NOTES.html#the-highlights-of-changes-made-in-petabridgecmd-v060-2)

--- a/src/Lighthouse/Dockerfile-linux
+++ b/src/Lighthouse/Dockerfile-linux
@@ -6,8 +6,6 @@ ENV CLUSTER_SEEDS "[]"
 ENV CLUSTER_IP ""
 ENV CLUSTER_PORT "4053"
 
-COPY ./bin/Release/netcoreapp2.1/publish/ /app
-
 # 9110 - Petabridge.Cmd
 # 4053 - Akka.Cluster
 EXPOSE 9110 4053
@@ -20,5 +18,15 @@ RUN dotnet tool install --global pbm
 ENV PATH="${PATH}:/root/.dotnet/tools"
 
 # RUN pbm help
+
+COPY ./bin/Release/netcoreapp2.1/publish/ /app
+
+FROM mcr.microsoft.com/dotnet/core/runtime:2.1 AS app
+WORKDIR /app
+
+COPY --from=base /app /app
+
+# copy .NET Core global tool
+COPY --from=base /root/.dotnet /root/.dotnet/
 
 CMD ["dotnet", "Lighthouse.dll"]

--- a/src/Lighthouse/Dockerfile-windows
+++ b/src/Lighthouse/Dockerfile-windows
@@ -6,8 +6,6 @@ ENV CLUSTER_SEEDS "[]"
 ENV CLUSTER_IP ""
 ENV CLUSTER_PORT "4053"
 
-COPY ./bin/Release/netcoreapp2.1/publish/ /app
-
 # 9110 - Petabridge.Cmd
 # 4053 - Akka.Cluster
 EXPOSE 9110 4053
@@ -20,5 +18,15 @@ EXPOSE 9110 4053
 #ENV PATH="${PATH}:/root/.dotnet/tools"
 
 # RUN pbm help
+
+COPY ./bin/Release/netcoreapp2.1/publish/ /app
+
+FROM mcr.microsoft.com/dotnet/core/runtime:2.1-nanoserver-1803 AS app
+WORKDIR /app
+
+COPY --from=base /app /app
+
+# copy .NET Core global tool
+# COPY --from=base /root/.dotnet /root/.dotnet/
 
 CMD ["dotnet", "Lighthouse.dll"]

--- a/src/common.props
+++ b/src/common.props
@@ -2,11 +2,9 @@
   <PropertyGroup>
     <Copyright>Copyright © 2015-2019 Petabridge, LLC</Copyright>
     <Authors>Petabridge</Authors>
-    <VersionPrefix>1.0.0</VersionPrefix>
-    <PackageReleaseNotes>Upgraded to Akka.NET v1.3.13
-Installed [Akka.Bootstrap.Docker](https://github.com/petabridge/akkadotnet-bootstrap)
-Added separately tagged [Windows and Linux Lighthouse Docker images to `petabridge/lighthouse` on DockerHub](https://hub.docker.com/r/petabridge/lighthouse).
-Upgraded to .NET 4.6.1 and .NET Core 2.1, respectively.</PackageReleaseNotes>
+    <VersionPrefix>1.1.0</VersionPrefix>
+    <PackageReleaseNotes>Reduced [Docker image size by a factor of 10](https://github.com/petabridge/lighthouse/pull/84).
+Upgraded to [Petabridge.Cmd v0.6.2](https://cmd.petabridge.com/articles/RELEASE_NOTES.html#the-highlights-of-changes-made-in-petabridgecmd-v060-2)</PackageReleaseNotes>
     <PackageIconUrl>https://petabridge.com/images/logo.png</PackageIconUrl>
     <PackageProjectUrl>
       https://github.com/petabridge/lighthouse

--- a/src/common.props
+++ b/src/common.props
@@ -25,6 +25,6 @@ Upgraded to .NET 4.6.1 and .NET Core 2.1, respectively.</PackageReleaseNotes>
     <NetFrameworkLibVersion>net461</NetFrameworkLibVersion>
     <NetFrameworkTestVersion>net461</NetFrameworkTestVersion>
     <AkkaVersion>1.3.13</AkkaVersion>
-    <PbmVersion>0.6.0</PbmVersion>
+    <PbmVersion>0.6.2</PbmVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
#### 1.1.0 June 26 2019 ####
* Reduced [Docker image size by a factor of 10](https://github.com/petabridge/lighthouse/pull/84).
* Upgraded to [Petabridge.Cmd v0.6.2](https://cmd.petabridge.com/articles/RELEASE_NOTES.html#the-highlights-of-changes-made-in-petabridgecmd-v060-2)