### PR TITLE
added v1.3.0 release notes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,2 +1,4 @@
-#### 1.2.0 July 29 2019 ####
-* Fixed problem with v1.1.0 image of Lighthouse, which prevented `pbm` from being executed internally via `docker exec`. `pbm` can now be called normally again from within the container.
+#### 1.3.0 November 22 2019 ####
+* [Enable SSL needs management](https://github.com/petabridge/lighthouse/issues/102)
+* Updated all underlying dependencies.
+* Updated Windows Server base Docker image.

--- a/src/common.props
+++ b/src/common.props
@@ -2,8 +2,10 @@
   <PropertyGroup>
     <Copyright>Copyright © 2015-2019 Petabridge, LLC</Copyright>
     <Authors>Petabridge</Authors>
-    <VersionPrefix>1.2.0</VersionPrefix>
-    <PackageReleaseNotes>Fixed problem with v1.1.0 image of Lighthouse, which prevented `pbm` from being executed internally via `docker exec`. `pbm` can now be called normally again from within the container.</PackageReleaseNotes>
+    <VersionPrefix>1.3.0</VersionPrefix>
+    <PackageReleaseNotes>[Enable SSL needs management](https://github.com/petabridge/lighthouse/issues/102)
+Updated all underlying dependencies.
+Updated Windows Server base Docker image.</PackageReleaseNotes>
     <PackageIconUrl>https://petabridge.com/images/logo.png</PackageIconUrl>
     <PackageProjectUrl>
       https://github.com/petabridge/lighthouse


### PR DESCRIPTION
#### 1.3.0 November 22 2019 ####
* [Enable SSL needs management](https://github.com/petabridge/lighthouse/issues/102)
* Updated all underlying dependencies.
* Updated Windows Server base Docker image.