### PR TITLE
Add default resolver to Lighthouse docker images.

### DIFF
--- a/src/Lighthouse/Dockerfile-linux
+++ b/src/Lighthouse/Dockerfile-linux
@@ -1,15 +1,6 @@
 FROM mcr.microsoft.com/dotnet/core/sdk:2.1 AS base
 WORKDIR /app
 
-# should be a comma-delimited list
-ENV CLUSTER_SEEDS "[]"
-ENV CLUSTER_IP ""
-ENV CLUSTER_PORT "4053"
-
-# 9110 - Petabridge.Cmd
-# 4053 - Akka.Cluster
-EXPOSE 9110 4053
-
 # Install Petabridge.Cmd client so it can be invoked remotely via
 # Docker or K8s 'exec` commands
 RUN dotnet tool install --global pbm 
@@ -28,5 +19,14 @@ COPY --from=base /root/.dotnet /root/.dotnet/
 
 # Needed because https://stackoverflow.com/questions/51977474/install-dotnet-core-tool-dockerfile
 ENV PATH="${PATH}:/root/.dotnet/tools"
+
+# should be a comma-delimited list
+ENV CLUSTER_SEEDS "[]"
+ENV CLUSTER_IP ""
+ENV CLUSTER_PORT "4053"
+
+# 9110 - Petabridge.Cmd
+# 4053 - Akka.Cluster
+EXPOSE 9110 4053
 
 CMD ["dotnet", "Lighthouse.dll"]

--- a/src/Lighthouse/Dockerfile-linux
+++ b/src/Lighthouse/Dockerfile-linux
@@ -24,6 +24,7 @@ ENV PATH="${PATH}:/root/.dotnet/tools"
 ENV CLUSTER_SEEDS "[]"
 ENV CLUSTER_IP ""
 ENV CLUSTER_PORT "4053"
+ENV AKKA__CLUSTER__SPLIT_BRAIN_RESOLVER__ACTIVE_STRATEGY "keep-majority"
 
 # 9110 - Petabridge.Cmd
 # 4053 - Akka.Cluster

--- a/src/Lighthouse/Dockerfile-windows
+++ b/src/Lighthouse/Dockerfile-windows
@@ -24,6 +24,7 @@ COPY --from=base /app /app
 ENV CLUSTER_SEEDS "[]"
 ENV CLUSTER_IP ""
 ENV CLUSTER_PORT "4053"
+ENV AKKA__CLUSTER__SPLIT_BRAIN_RESOLVER__ACTIVE_STRATEGY "keep-majority"
 
 # 9110 - Petabridge.Cmd
 # 4053 - Akka.Cluster

--- a/src/Lighthouse/Dockerfile-windows
+++ b/src/Lighthouse/Dockerfile-windows
@@ -1,15 +1,6 @@
 FROM mcr.microsoft.com/dotnet/core/sdk:2.1-nanoserver-1803 AS base
 WORKDIR /app
 
-# should be a comma-delimited list
-ENV CLUSTER_SEEDS "[]"
-ENV CLUSTER_IP ""
-ENV CLUSTER_PORT "4053"
-
-# 9110 - Petabridge.Cmd
-# 4053 - Akka.Cluster
-EXPOSE 9110 4053
-
 # Install Petabridge.Cmd client so it can be invoked remotely via
 # Docker or K8s 'exec` commands
 #RUN dotnet tool install --global pbm 
@@ -28,5 +19,14 @@ COPY --from=base /app /app
 
 # copy .NET Core global tool
 # COPY --from=base /root/.dotnet /root/.dotnet/
+
+# should be a comma-delimited list
+ENV CLUSTER_SEEDS "[]"
+ENV CLUSTER_IP ""
+ENV CLUSTER_PORT "4053"
+
+# 9110 - Petabridge.Cmd
+# 4053 - Akka.Cluster
+EXPOSE 9110 4053
 
 CMD ["dotnet", "Lighthouse.dll"]


### PR DESCRIPTION
Using the recently added environment variable configuration via `akkadotnet-bootstrap`, I've added the default configuration as follows:

`akka.cluster.split-brain-resolver.active-strategy=keep-majority`

Closes #115 