### PR TITLE
added v1.3.3 release notes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,3 @@
-#### 1.3.2 May 1 2020 ####
-* Updated to use Akka.NET v1.4.5.
-* Updated Docker .NET Core runtime base image from nanoserver-1803 to nanoserver-1809, 1803 are deprecated.
-* Followed [Akka.Remote performance best practices](https://getakka.net/articles/remoting/performance.html) and disabled batching for Lighthouse in order to reduce CPU utilization by default.
+#### 1.3.3 May 28 2020 ####
+* Updated to use Akka.NET v1.4.7.
+* Resolved [issue with Lighthouse v1.3.2 where `pbm` did not work when executed via interactive shell](https://github.com/petabridge/lighthouse/issues/151)


### PR DESCRIPTION
#### 1.3.3 May 28 2020 ####
* Updated to use Akka.NET v1.4.7.
* Resolved [issue with Lighthouse v1.3.2 where `pbm` did not work when executed via interactive shell](https://github.com/petabridge/lighthouse/issues/151)