### PR TITLE
added 1.7.0 release notes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,7 @@
-#### 1.6.2 June 27 2022 ####
+#### 1.7.0 August 10 2022 ####
 
-* [Bumped Akka.NET version to 1.4.39](https://github.com/akkadotnet/akka.net/releases/tag/1.4.39)
-* [Bumped Akka.Hosting from 0.2.2 to 0.3.4](https://github.com/petabridge/lighthouse/pull/266).
+* [Bumped Akka.NET version to 1.4.40](https://github.com/akkadotnet/akka.net/releases/tag/1.4.40)
+* [Bumped Akka.Hosting to 0.4.1](https://github.com/akkadotnet/Akka.Hosting/releases/tag/0.4.1).
+* [Upgraded to Petabridge.Cmd 1.1.0](https://cmd.petabridge.com/articles/RELEASE_NOTES.html) and used Akka.Hosting support;
+* Added ARM64 support to Docker image `petabridge/lighthouse:latest` and all other Linux images for Lighthouse.
+* Migrated onto .NET 6.

--- a/src/common.props
+++ b/src/common.props
@@ -2,9 +2,12 @@
   <PropertyGroup>
     <Copyright>Copyright © 2015-2022 Petabridge, LLC</Copyright>
     <Authors>Petabridge</Authors>
-    <VersionPrefix>1.6.2</VersionPrefix>
-    <PackageReleaseNotes>[Bumped Akka.NET version to 1.4.39](https://github.com/akkadotnet/akka.net/releases/tag/1.4.39)
-[Bumped Akka.Hosting from 0.2.2 to 0.3.4](https://github.com/petabridge/lighthouse/pull/266).</PackageReleaseNotes>
+    <VersionPrefix>1.7.0</VersionPrefix>
+    <PackageReleaseNotes>[Bumped Akka.NET version to 1.4.40](https://github.com/akkadotnet/akka.net/releases/tag/1.4.40)
+[Bumped Akka.Hosting to 0.4.1](https://github.com/akkadotnet/Akka.Hosting/releases/tag/0.4.1).
+[Upgraded to Petabridge.Cmd 1.1.0](https://cmd.petabridge.com/articles/RELEASE_NOTES.html) and used Akka.Hosting support;
+Added ARM64 support to Docker image `petabridge/lighthouse:latest` and all other Linux images for Lighthouse.
+Migrated onto .NET 6.</PackageReleaseNotes>
     <PackageIconUrl>https://petabridge.com/images/logo.png</PackageIconUrl>
     <PackageProjectUrl>
       https://github.com/petabridge/lighthouse


### PR DESCRIPTION
#### 1.7.0 August 10 2022 ####

* [Bumped Akka.NET version to 1.4.40](https://github.com/akkadotnet/akka.net/releases/tag/1.4.40)
* [Bumped Akka.Hosting to 0.4.1](https://github.com/akkadotnet/Akka.Hosting/releases/tag/0.4.1).
* [Upgraded to Petabridge.Cmd 1.1.0](https://cmd.petabridge.com/articles/RELEASE_NOTES.html) and used Akka.Hosting support;
* Added ARM64 support to Docker image `petabridge/lighthouse:latest` and all other Linux images for Lighthouse.
* Migrated onto .NET 6.