### PR TITLE
Added v1.7.2 release notes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,5 @@
-#### 1.7.1 October 24 2022 ####
+#### 1.7.2 December 20 2022 ####
 
-* [Bumped Akka.NET version to 1.4.45](https://github.com/akkadotnet/akka.net/releases/tag/1.4.45)
-* [Bumped Akka.Hosting to 0.5.1](https://github.com/akkadotnet/Akka.Hosting/releases/tag/0.5.1).
-* [Upgraded to Petabridge.Cmd 1.1.3](https://cmd.petabridge.com/articles/RELEASE_NOTES.html) and used Akka.Hosting support;
+* [Bumped Akka.NET version to 1.4.47](https://github.com/akkadotnet/akka.net/releases/tag/1.4.47)
+* [Added Serilog logging, configurable by `/app/serilog.json`](https://github.com/petabridge/lighthouse/pull/304)
+* [Upgraded to Petabridge.Cmd 1.2.1](https://cmd.petabridge.com/articles/RELEASE_NOTES.html) and used Akka.Hosting support.


### PR DESCRIPTION
#### 1.7.2 December 20 2022 ####

* [Bumped Akka.NET version to 1.4.47](https://github.com/akkadotnet/akka.net/releases/tag/1.4.47)
* [Added Serilog logging, configurable by `/app/serilog.json`](https://github.com/petabridge/lighthouse/pull/304)
* [Upgraded to Petabridge.Cmd 1.2.1](https://cmd.petabridge.com/articles/RELEASE_NOTES.html) and used Akka.Hosting support.