### PR TITLE
Added v1.8.0 release notes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,4 +3,4 @@
 * [Bumped Akka.NET version to 1.5.2](https://github.com/akkadotnet/akka.net/releases/tag/1.5.2)
 * **Major change**: Lighthouse now uses [Akka.Cluster's default split brain resolver: `keep-majority`](https://getakka.net/articles/clustering/split-brain-resolver.html)
 * Lighthouse now runs on .NET 7.0
-* DynamicPGO and ServerGC are both enabled, which should help reduce Lighthouse's latency when processing cluster system messages from other nodes.
+* Enabled `TieredPGO` and `ServerGarbageCollection`, which should help reduce Lighthouse's latency when processing cluster system messages from other nodes.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,6 @@
-#### 1.8.0 March 02 2023 ####
+#### 1.8.0 April 07 2023 ####
 
-* [Bumped Akka.NET version to 1.5.0](https://github.com/akkadotnet/akka.net/releases/tag/1.5.0)
+* [Bumped Akka.NET version to 1.5.2](https://github.com/akkadotnet/akka.net/releases/tag/1.5.2)
+* **Major change**: Lighthouse now uses [Akka.Cluster's default split brain resolver: `keep-majority`](https://getakka.net/articles/clustering/split-brain-resolver.html)
+* Lighthouse now runs on .NET 7.0
+* DynamicPGO and ServerGC are both enabled, which should help reduce Lighthouse's latency when processing cluster system messages from other nodes.


### PR DESCRIPTION
#### 1.8.0 April 07 2023 ####

* [Bumped Akka.NET version to 1.5.2](https://github.com/akkadotnet/akka.net/releases/tag/1.5.2)
* **Major change**: Lighthouse now uses [Akka.Cluster's default split brain resolver: `keep-majority`](https://getakka.net/articles/clustering/split-brain-resolver.html)
* Lighthouse now runs on .NET 7.0
* DynamicPGO and ServerGC are both enabled, which should help reduce Lighthouse's latency when processing cluster system messages from other nodes.